### PR TITLE
Remove deprecated sponsor entries from sponsors.json

### DIFF
--- a/sponsors.json
+++ b/sponsors.json
@@ -3205,9 +3205,6 @@
       "BESTSELLER Service BV",
       "Bestseller Wholesale Benelux BV"
     ],
-    "betabit": [
-      "Betabit Amsterdam BV"
-    ],
     "betaselect": [
       "Betaselect BV"
     ],
@@ -4854,9 +4851,6 @@
       "CG Drives & Automation Netherlands BV",
       "CG Holding BV"
     ],
-    "cge": [
-      "CGE Risk Management Solutions BV"
-    ],
     "cgg": [
       "CGG Services (NL) BV"
     ],
@@ -5852,9 +5846,6 @@
     ],
     "copernicos": [
       "Copernicos Nederland BV"
-    ],
-    "copersucar": [
-      "Copersucar Europe Sociedad Limitada"
     ],
     "copiatek": [
       "Copiatek Scan & Computer Solution BV"
@@ -8623,9 +8614,6 @@
     "esperante": [
       "Esperante Development BV"
     ],
-    "esprit": [
-      "Esprit Europe BV"
-    ],
     "esri": [
       "ESRI Global, Inc"
     ],
@@ -10770,9 +10758,6 @@
     ],
     "good": [
       "Good Will Instrument Euro BV"
-    ],
-    "goodfuels": [
-      "GoodFuels BV"
     ],
     "goodhabitz": [
       "GoodHabitz BV"
@@ -18572,7 +18557,6 @@
       "NPSP BV"
     ],
     "nrg": [
-      "NRG Flow BV",
       "NRG Imports BV"
     ],
     "ns": [
@@ -19603,9 +19587,6 @@
     ],
     "paques": [
       "Paques Technology BV"
-    ],
-    "parable": [
-      "Parable BV"
     ],
     "paradigm": [
       "Paradigm Group BV",
@@ -25952,9 +25933,6 @@
     "the-bank": [
       "The Bank of New York Mellon SA/NV"
     ],
-    "the-bim": [
-      "The BIM Engineers BV"
-    ],
     "the-bookie": [
       "The Bookie BV"
     ],
@@ -29295,7 +29273,6 @@
       "Xeamos BV"
     ],
     "xebia": [
-      "Xebia Data BV",
       "Xebia Nederland BV",
       "Xccelerate"
     ],


### PR DESCRIPTION
This pull request includes several changes to the `sponsors.json` file, mainly involving the removal of specific sponsors. Below is a summary of the most important changes:

Removal of sponsors:

* Removed `betabit` sponsor entry.
* Removed `cge` sponsor entry.
* Removed `copersucar` sponsor entry.
* Removed `esprit` sponsor entry.
* Removed `goodfuels` sponsor entry.
* Removed `parable` sponsor entry.
* Removed `the-bim` sponsor entry.

Modification of existing sponsors:

* Removed `NRG Flow BV` from the `nrg` sponsor entry.
* Removed `Xebia Data BV` from the `xebia` sponsor entry.