### PR TITLE
Update version number to 1.6.1 in manifest.json for KMatch extension

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "KMatch - Dutch Sponsor Job Finder",
-  "version": "1.6",
+  "version": "1.6.1",
   "description": "Find LinkedIn jobs from Dutch companies authorized to sponsor Kennismigrant visas",
   "host_permissions": [
     "*://*.linkedin.com/*"


### PR DESCRIPTION
This pull request includes a small change to the `manifest.json` file. The version number has been incremented from `1.6` to `1.6.1`. 

* [`manifest.json`](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L4-R4): Updated the version number from `1.6` to `1.6.1`.